### PR TITLE
fix: remove comments after ide config dir

### DIFF
--- a/profile/public/dotfiles/.gitignore_global
+++ b/profile/public/dotfiles/.gitignore_global
@@ -45,9 +45,9 @@ Thumbs.db
 #######
 # IDE #
 #######
-nbproject   # for NetBeans
-.idea       # for *Storm
-.vscode     # for VScode
+nbproject
+.idea
+.vscode
 .project
 .buildpath
 .setting/org.eclipse.php.core.prefs


### PR DESCRIPTION
comments at the end of line doesn't seem to be supported in gitignore